### PR TITLE
Add PHP errors test page (FR-6108)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Support\ImagickPerfRunner;
+use App\Support\PhpErrorEmitter;
 use App\Support\Renditions;
 use App\Tests\Test;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Log;
 use Imagick;
@@ -107,6 +109,51 @@ class Controller extends BaseController
         );
 
         return response()->json($runner->run($count));
+    }
+
+    /**
+     * PHP errors test page (FR-6108).
+     *
+     * Renders instantly. Query params prefill the controls and trigger an
+     * automatic run; with no params the page is idle until a button is clicked.
+     */
+    public function phpErrors(Request $request)
+    {
+        return view('php-errors', [
+            'type' => $request->query('errors'),
+            'count' => $request->query('count'),
+            'concurrency' => $request->query('concurrency'),
+            'sleep' => $request->query('sleep'),
+            'abort' => $request->query('abort'),
+        ]);
+    }
+
+    /**
+     * Produce exactly one PHP/HTTP error and return. Called repeatedly by the
+     * php-errors page via AJAX.
+     *
+     * 500/503/504 throw or abort (the HTTP status IS the result); warning/info
+     * log a line and return 200 JSON so the page can show "logged".
+     */
+    public function emit(Request $request): JsonResponse
+    {
+        $type = (string) $request->query('type', 'random');
+
+        if (! PhpErrorEmitter::isValidType($type)) {
+            abort(400, 'Unknown error type: ' . $type);
+        }
+
+        $abort = filter_var($request->query('abort', false), FILTER_VALIDATE_BOOLEAN);
+        $sleep = PhpErrorEmitter::clampSleep($request->query('sleep', PhpErrorEmitter::SLEEP_DEFAULT));
+        $resolved = PhpErrorEmitter::resolveType($type);
+
+        (new PhpErrorEmitter)->emit($resolved, $abort, $sleep);
+
+        // Only warning/info fall through to here (HTTP 200).
+        return response()->json([
+            'type' => $resolved,
+            'status' => 'logged',
+        ]);
     }
 
     /**

--- a/app/Support/PhpErrorEmitter.php
+++ b/app/Support/PhpErrorEmitter.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Generates a single, deliberate PHP / HTTP error for the testrabbit
+ * "PHP errors test" page (FR-6108).
+ *
+ * One call == one error. The browser fires many of these through a bounded
+ * concurrency pool; this class is the single place the actual error semantics
+ * live, so the controller stays thin and the behaviour is easy to reason about.
+ */
+class PhpErrorEmitter
+{
+    /** Concrete error types (everything except the "random" meta-type). */
+    public const TYPES = ['500', '503', '504', 'warning', 'info'];
+
+    public const SLEEP_MIN = 1;
+    public const SLEEP_MAX = 600;
+    public const SLEEP_DEFAULT = 65;
+
+    /**
+     * Whether $type is something we can emit (incl. the "random" meta-type).
+     */
+    public static function isValidType(string $type): bool
+    {
+        return $type === 'random' || in_array($type, self::TYPES, true);
+    }
+
+    /**
+     * Clamp a raw ?sleep= value into the allowed range.
+     */
+    public static function clampSleep($raw): int
+    {
+        $seconds = (int) $raw;
+
+        if ($seconds < self::SLEEP_MIN) {
+            return self::SLEEP_MIN;
+        }
+
+        if ($seconds > self::SLEEP_MAX) {
+            return self::SLEEP_MAX;
+        }
+
+        return $seconds;
+    }
+
+    /**
+     * Resolve the "random" meta-type to a concrete type; pass others through.
+     */
+    public static function resolveType(string $type): string
+    {
+        if ($type === 'random') {
+            return self::TYPES[array_rand(self::TYPES)];
+        }
+
+        return $type;
+    }
+
+    /**
+     * Emit one error of the (already-resolved, concrete) $type.
+     *
+     * - 500: throw a real exception (faithful) or abort(500) (instant)
+     * - 503: abort(503) — a real overload-503 can't be forced on demand
+     * - 504: sleep past the gateway timeout then abort(504) (faithful), or
+     *        abort(504) immediately (instant)
+     * - warning / info: write a line to PHP's error log (stderr), HTTP 200
+     *
+     * For 500/503/504 this never returns — it throws or aborts. For warning and
+     * info it returns the type so the caller can report it as "logged".
+     */
+    public function emit(string $type, bool $abort, int $sleep): string
+    {
+        switch ($type) {
+            case '500':
+                if ($abort) {
+                    abort(500);
+                }
+                throw new \RuntimeException('testrabbit: synthetic 500 error');
+
+            case '503':
+                abort(503);
+
+            case '504':
+                if (! $abort) {
+                    // Run past the gateway's upstream timeout. Behind the
+                    // fortrabbit gateway this produces a genuine 504 while PHP
+                    // is still sleeping; locally (no gateway) PHP falls through
+                    // to the abort() below after $sleep seconds.
+                    set_time_limit(0);
+                    sleep($sleep);
+                }
+                abort(504);
+
+            case 'warning':
+                error_log('testrabbit: synthetic PHP warning');
+
+                return 'warning';
+
+            case 'info':
+                error_log('testrabbit: synthetic PHP info');
+
+                return 'info';
+        }
+
+        // The controller validates first, so this is defensive only.
+        abort(400, 'Unknown error type: ' . $type);
+    }
+}

--- a/config/database.php
+++ b/config/database.php
@@ -62,7 +62,10 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                // Pdo\Mysql exists only on PHP 8.4+; PDO::MYSQL_ATTR_SSL_CA is
+                // deprecated on 8.5. Pick per version so we stay clean across
+                // PHP versions.
+                (PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,11 @@ RUN /docker-scripts/setup-laravel-dirs.sh
 # Run composer install
 RUN composer install --no-interaction --prefer-dist --no-scripts --no-cache
 
-# Use PHP's built in web server
+# Use PHP's built in web server. It is single-threaded by default, so one slow
+# request (e.g. a faithful 504 that sleeps) would block the whole server and
+# freeze the site. PHP_CLI_SERVER_WORKERS spawns multiple worker processes so
+# concurrent requests — like a series of 503/504 error tests — are handled in
+# parallel, closer to the FPM setup on the real platform.
+ENV PHP_CLI_SERVER_WORKERS=5
 EXPOSE 8000
 CMD ["php", "-S", "0.0.0.0:8000", "-t", "public"]

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -69,6 +69,10 @@
                     <a class="border-dotted hover:border-solid border-b border-gray-600 mr-2" href="info.php" target="_blank">PHP info</a>
                     <x-link></x-link>
                 </li>
+                <li class="mt-2 flex">
+                    <a class="border-dotted hover:border-solid border-b border-gray-600 mr-2" href="/php-errors">PHP error tests</a>
+                    <x-link></x-link>
+                </li>
             </ul>
             <h3 class="text-lg font-bold mt-4 mb-2">Test Workers</h3>
             <ol class="list-decimal ml-5">

--- a/resources/views/php-errors.blade.php
+++ b/resources/views/php-errors.blade.php
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>TestRabbit — PHP errors</title>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Nunito', sans-serif; }
+        [x-cloak] { display: none !important; }
+    </style>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="//unpkg.com/alpinejs" defer></script>
+</head>
+<body>
+@php
+    $types = ['500', '503', '504', 'warning', 'info', 'random'];
+    $initType = in_array($type, $types, true) ? $type : null;
+    $initCount = (int) ($count ?? 0);
+    $initCount = ($initCount >= 1 && $initCount <= 200) ? $initCount : 10;
+    $initConcurrency = (int) ($concurrency ?? 0);
+    $initConcurrency = $initConcurrency >= 1 ? min($initConcurrency, 200) : 5;
+    $initSleep = (int) ($sleep ?? 0);
+    $initSleep = ($initSleep >= 1 && $initSleep <= 600) ? $initSleep : 65;
+    $initAbort = filter_var($abort ?? false, FILTER_VALIDATE_BOOLEAN);
+@endphp
+<div class="relative flex justify-center min-h-screen bg-gray-100 sm:items-start py-4">
+    <div class="w-2/3 mx-auto pt-4"
+         x-data="errorsApp({
+             type: @json($initType),
+             count: {{ $initCount }},
+             concurrency: {{ $initConcurrency }},
+             sleep: {{ $initSleep }},
+             abort: {{ $initAbort ? 'true' : 'false' }},
+         })">
+
+        <div class="flex justify-between items-baseline mb-4">
+            <h1 class="text-2xl font-bold">PHP errors</h1>
+            <a class="border-dotted hover:border-solid border-b border-gray-600" href="/">&larr; back to tests</a>
+        </div>
+
+        {{-- Controls --}}
+        <div class="bg-white mb-4 p-4 rounded-lg">
+            <div class="flex items-center flex-wrap gap-2 mb-3">
+                <span class="font-semibold mr-1">Generate:</span>
+                @foreach ($types as $t)
+                    <button type="button"
+                            @click="start('{{ $t }}')"
+                            :disabled="running"
+                            :class="type === '{{ $t }}' ? 'bg-gray-800 text-white' : 'bg-gray-100 hover:bg-gray-200'"
+                            class="px-3 py-1 rounded font-semibold disabled:opacity-50">{{ $t }}</button>
+                @endforeach
+                <button type="button"
+                        x-show="running" x-cloak
+                        @click="stop()"
+                        class="ml-auto px-4 py-1 rounded bg-red-600 hover:bg-red-700 text-white font-semibold">
+                    Stop
+                </button>
+            </div>
+
+            <div class="flex items-center flex-wrap gap-4 text-sm">
+                <label class="flex items-center gap-1">
+                    <span class="text-gray-600">count</span>
+                    <input type="number" min="1" max="200" x-model.number="count" :disabled="running"
+                           class="w-20 px-2 py-1 border border-gray-300 rounded disabled:opacity-50">
+                </label>
+                <label class="flex items-center gap-1">
+                    <span class="text-gray-600">concurrency</span>
+                    <input type="number" min="1" max="200" x-model.number="concurrency" :disabled="running"
+                           class="w-20 px-2 py-1 border border-gray-300 rounded disabled:opacity-50">
+                </label>
+                <label class="flex items-center gap-1">
+                    <span class="text-gray-600">504 sleep (s)</span>
+                    <input type="number" min="1" max="600" x-model.number="sleep" :disabled="running"
+                           class="w-20 px-2 py-1 border border-gray-300 rounded disabled:opacity-50">
+                </label>
+                <label class="flex items-center gap-1">
+                    <input type="checkbox" x-model="abort" :disabled="running">
+                    <span class="text-gray-600">instant (abort)</span>
+                </label>
+            </div>
+            <div class="text-xs text-gray-500 mt-2">
+                Faithful mode (default): 500 throws a real exception, 504 sleeps past the gateway timeout, 503 is abort(503), warning/info write to the PHP log.
+                Instant mode emits 500/503/504 immediately via <code>abort()</code>.
+            </div>
+        </div>
+
+        {{-- Progress + summary --}}
+        <div x-show="total > 0" x-cloak class="bg-white mb-4 p-4 rounded-lg">
+            <div class="flex justify-between items-baseline mb-2 text-sm">
+                <span class="font-semibold">
+                    <span x-text="done"></span> / <span x-text="total"></span> done
+                    <span x-show="running" class="text-gray-500">· <span x-text="inFlight"></span> in flight</span>
+                </span>
+                <span>
+                    <span class="text-emerald-700" x-text="okCount + ' ✓'"></span>
+                    <span class="text-red-600 ml-2" x-text="failCount + ' ✗'"></span>
+                </span>
+            </div>
+            <div class="w-full bg-gray-100 rounded h-2 overflow-hidden">
+                <div class="bg-emerald-600 h-2 transition-all" :style="'width: ' + pct + '%'"></div>
+            </div>
+            <div class="flex flex-wrap gap-2 mt-3 text-xs font-mono">
+                <template x-for="[code, n] in statusEntries" :key="code">
+                    <span class="px-2 py-0.5 rounded bg-gray-100"
+                          x-text="(code === '0' ? 'net' : code) + ' × ' + n"></span>
+                </template>
+            </div>
+        </div>
+
+        {{-- Results list --}}
+        <div x-show="rows.length > 0" x-cloak class="bg-white mb-4 p-4 rounded-lg">
+            <div class="max-h-96 overflow-y-auto">
+                <table class="w-full text-sm font-mono">
+                    <tbody>
+                        <template x-for="row in rows" :key="row.n">
+                            <tr class="border-b border-gray-100" :class="rowClass(row)">
+                                <td class="py-1 pr-3 text-right text-gray-400" x-text="'#' + row.n"></td>
+                                <td class="py-1 pr-3" x-text="row.type"></td>
+                                <td class="py-1 pr-3 text-right" x-text="row.status === null ? '' : (row.status === 0 ? 'net' : row.status)"></td>
+                                <td class="py-1 pr-3" x-text="row.label"></td>
+                                <td class="py-1 text-right text-gray-500" x-text="row.pending ? '…' : fmtMs(row.ms)"></td>
+                                <td class="py-1 pl-3 text-right" x-text="row.pending ? '' : (row.ok ? '✓' : '✗')"></td>
+                            </tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<script>
+    function errorsApp(cfg) {
+        return {
+            type: cfg.type,
+            count: cfg.count,
+            concurrency: cfg.concurrency,
+            sleep: cfg.sleep,
+            abort: cfg.abort,
+
+            running: false,
+            stopped: false,
+            rows: [],
+            total: 0,
+            done: 0,
+            inFlight: 0,
+            okCount: 0,
+            failCount: 0,
+            byStatus: {},
+            nextIndex: 0,
+            _abort: null,
+
+            init() {
+                // Auto-run when the page is opened with an ?errors= param.
+                if (this.type !== null) this.start(this.type);
+            },
+
+            async start(type) {
+                if (this.running) return;
+                this.type = type;
+                this.resetRun();
+                this.running = true;
+                this.stopped = false;
+                this._abort = new AbortController();
+                this.total = this.clamp(this.count, 1, 200);
+                this.count = this.total;
+
+                const pool = Math.max(1, Math.min(this.clamp(this.concurrency, 1, 200), this.total));
+                const workers = [];
+                for (let w = 0; w < pool; w++) workers.push(this.worker());
+                await Promise.all(workers);
+
+                this.running = false;
+            },
+
+            async worker() {
+                while (!this.stopped) {
+                    const i = this.nextIndex;
+                    if (i >= this.total) return;
+                    this.nextIndex++;
+                    await this.emitOne(i);
+                }
+            },
+
+            async emitOne(i) {
+                const row = { n: i + 1, type: this.type, status: null, label: '…', ms: 0, ok: false, pending: true };
+                this.rows.push(row);
+                this.inFlight++;
+
+                const qs = new URLSearchParams({
+                    type: this.type,
+                    abort: this.abort ? '1' : '0',
+                    sleep: String(this.sleep),
+                });
+                const t0 = performance.now();
+
+                try {
+                    const r = await fetch('/php-errors/emit?' + qs.toString(), { signal: this._abort.signal });
+                    row.ms = performance.now() - t0;
+                    row.status = r.status;
+                    if (r.ok) {
+                        let body = {};
+                        try { body = await r.json(); } catch (e) {}
+                        row.type = body.type || this.type;
+                        row.label = body.status || 'ok';
+                        row.ok = true;
+                        this.okCount++;
+                    } else {
+                        row.label = 'HTTP ' + r.status;
+                        this.failCount++;
+                    }
+                    this.tally(r.status);
+                } catch (e) {
+                    row.ms = performance.now() - t0;
+                    if (e.name === 'AbortError') {
+                        // User hit Stop — cancelled, not a failure.
+                        row.status = null;
+                        row.label = 'aborted';
+                    } else {
+                        row.status = 0;
+                        row.label = 'network';
+                        this.failCount++;
+                        this.tally(0);
+                    }
+                } finally {
+                    row.pending = false;
+                    this.inFlight--;
+                    this.done++;
+                }
+            },
+
+            stop() {
+                this.stopped = true;
+                // Cancel in-flight requests too, so a long faithful-504 run
+                // stops immediately instead of waiting out each sleep.
+                if (this._abort) this._abort.abort();
+            },
+
+            resetRun() {
+                this.rows = [];
+                this.total = 0;
+                this.done = 0;
+                this.inFlight = 0;
+                this.okCount = 0;
+                this.failCount = 0;
+                this.byStatus = {};
+                this.nextIndex = 0;
+            },
+
+            tally(status) {
+                const key = String(status);
+                this.byStatus = { ...this.byStatus, [key]: (this.byStatus[key] || 0) + 1 };
+            },
+
+            clamp(v, lo, hi) {
+                v = parseInt(v) || lo;
+                return Math.max(lo, Math.min(hi, v));
+            },
+
+            get statusEntries() {
+                return Object.entries(this.byStatus).sort((a, b) => b[1] - a[1]);
+            },
+
+            get pct() {
+                return this.total ? Math.round((this.done / this.total) * 100) : 0;
+            },
+
+            rowClass(row) {
+                if (row.pending) return 'text-gray-400';
+                if (row.ok) return 'text-emerald-700';
+                if (row.status >= 500) return 'text-red-600';
+                return 'text-gray-500';
+            },
+
+            fmtMs(ms) {
+                return (ms / 1000).toFixed(2) + ' s';
+            },
+        };
+    }
+</script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,4 +8,7 @@ Route::get('/', [Controller::class, 'index']);
 Route::get('/imagick-perf', [Controller::class, 'perf']);
 Route::get('/imagick-perf/run', [Controller::class, 'perfRun']);
 
+Route::get('/php-errors', [Controller::class, 'phpErrors']);
+Route::get('/php-errors/emit', [Controller::class, 'emit']);
+
 Route::get('/tests/{test}', [Controller::class, 'test']);


### PR DESCRIPTION
🤖

New **/php-errors** page to deliberately generate 500/503/504 errors and warning/info log lines on demand — for the logging test ([FR-6106](https://linear.app/fortrabbit/issue/FR-6106/test-logging-in-dev-cluster)) and 503/504 perf testing across platforms.

* Type buttons (500/503/504/warning/info/random), `count`, editable `concurrency` + `sleep`, **instant (abort)** toggle.
* Faithful mode: real 500, 504 sleeps past the gateway timeout, 503 = abort(503), warning/info via `error_log()`. Instant mode emits via `abort()`.
* Bounded-concurrency dispatch, live results list, query-param auto-run, Stop (aborts in-flight).
* Dockerfile: `PHP_CLI_SERVER_WORKERS=5` so the single-threaded `php -S` test server doesn't freeze on a sleeping 504.

Design: KB → *Old platform/Testing/Testrabbit PHP errors test design (*[FR-6108](https://linear.app/fortrabbit/issue/FR-6108/create-a-php-errors-test-in-testrabbit)*)*. Verified on PHP 8.3/8.4 (docker).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)